### PR TITLE
Fix advisory 1432.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1844,9 +1844,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
+      "version": "1.2.2",
+      "resolved": "http://localhost:4873/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "trim-newlines": {
       "version": "1.0.0",


### PR DESCRIPTION
Fix for command injection in tree-kill (via ts-node-dev): <https://npmjs.com/advisories/1432>